### PR TITLE
escaping javascript, important for functions containing single quote

### DIFF
--- a/app/views/main/function.html.erb
+++ b/app/views/main/function.html.erb
@@ -9,8 +9,8 @@ $(document).ready(function() {
 		varId: <%= @function.id %>,
 		library: "<%= @function.library.name %>",
 		version: "<%= @function.library.version %>",
-		editExampleFormHTML: '<%= (render :partial => '/examples/edit_example_form').gsub("\n", "")%>',
-		editCommentFormHTML: '<%= (render :partial => '/comments/edit_comment_form').gsub("\n", "")%>',
+		editExampleFormHTML: '<%= escape_javascript(render :partial => '/examples/edit_example_form').gsub("\n", "")%>',
+		editCommentFormHTML: '<%= escape_javascript(render :partial => '/comments/edit_comment_form').gsub("\n", "")%>',
 	})
 })
 </script>

--- a/app/views/management/function.html.erb
+++ b/app/views/management/function.html.erb
@@ -3,7 +3,7 @@
 <script type="text/javascript" charset="utf-8">
 	$(document).ready(function() {
 		CD.Examples.init({
-			editExampleFormHTML: '<%= (render :partial => '/examples/edit_example_form').gsub("\n", "")%>'
+			editExampleFormHTML: '<%= escape_javascript(render :partial => '/examples/edit_example_form').gsub("\n", "")%>'
 		})
 	})
 </script>


### PR DESCRIPTION
This simple change fixes an issue with functions containing single quote like dec'
