### PR TITLE
update clojure-contrib link and description to reflect changes in project

### DIFF
--- a/app/views/main/index.html.erb
+++ b/app/views/main/index.html.erb
@@ -22,8 +22,8 @@
 			<div class="core_libraries">
 				<div class="library">
 					<h3><a href="/clojure_contrib">Clojure Contrib</a></h3>
-					<a href="http://clojure.github.com/clojure-contrib/">http://clojure.github.com/clojure-contrib</a>
-					<p>The user contributions library, clojure.contrib, is a collection of namespaces each of which implements features that we believe may be useful to a large part of the clojure community.</p>
+					<a href="https://github.com/clojure/clojure-contrib/">clojure-contrib</a>
+					<p>clojure-contrib is a collection of projects implementing features that we believe may be useful to a large part of the clojure community.</p>
 				</div>
 			</div>
 		</div>
@@ -71,11 +71,11 @@
 			<p>ClojureDocs provides a simple <a href="http://api.clojuredocs.org">API</a> for you to use to develop applications and tools that integrate with the ClojureDocs backend:</p>
 			<ul>
 			  <li>Look up <a href="http://api.clojuredocs.org/examples/clojure.core/map">examples</a>,
-			  <a href="http://api.clojuredocs.org/comments/clojure.contrib.json/read-json">comments</a>, 
+			  <a href="http://api.clojuredocs.org/comments/clojure.contrib.json/read-json">comments</a>,
 			  and
 			  <a href="http://api.clojuredocs.org/see-also/clojure.test/are">see-alsos</a> by function name.</li>
 			  <li>Search for functions by <a href="http://api.clojuredocs.org/search/clojure.core/map">name</a> (namespace optional)</li>
-			  <li>See a <a href="http://api.clojuredocs.org/versions/clojure.core/map">list of the versions</a> that ClojureDocs knows about.</li> 
+			  <li>See a <a href="http://api.clojuredocs.org/versions/clojure.core/map">list of the versions</a> that ClojureDocs knows about.</li>
 			</ul>
 			</div>
 			<div class="beta_status">


### PR DESCRIPTION
Hi,
  Since clojure.contrib doesn't exist as a library for the latest versions of clojure, I thought it'd be helpful to point them to the readme explaining it's been split up. We may want to update /clojure_contrib to explain some of this as well.
