### PR TITLE
Use Mystery Man as default avatar instead of logo

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,7 +2,7 @@
 module ApplicationHelper
   def grav_url_for(email, size=80)
     digest = Digest::MD5.hexdigest(email)
-    return "http://www.gravatar.com/avatar/" + digest + "?s=" + size.to_s
+    return "http://www.gravatar.com/avatar/" + digest + "?s=" + size.to_s + "&d=mm"
   end
   
   def font_size_for_weight(weight)


### PR DESCRIPTION
Currently if a user hasn't set up a gravatar, we
show the gravatar logo, which draws attention away
from existing avatars.

Instead, we could show just a silhouetted outline.

See http://secure.gravatar.com/site/implement/images/
