### PR TITLE
Add Clojure 1.7 vars to ClojureDocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,13 @@ sudo service clojuredocs-web-2 restart
 
 ## Reqs
 
+* [> JDK 7](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
+* [JCE Unlimited Strength Jurisdiction Policy Files](http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html)
 * [lein](http://leiningen.org)
 * [foreman](https://github.com/ddollar/foreman) (see `Procfile`, `bin/dev`)
 * [less](http://lesscss.org/)
 * MongoDB
+
 
 
 ## Dev

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Clojure vars are pulled directly from the runtime, and are not stored in the dat
 
 * Change the Clojure dep in `project.clj`
 * Update the version string and source base url in `clojuredocs.search/clojure-lib`
+* Update the github URL in `clojuredocs.pages.vars/source-url`.
 
 
 ### App Structure

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :min-lein-version "2.0.0"
   :source-paths ["src/clj" "target/generated/clj"]
   :test-paths ["test/clj"]
-  :dependencies [[org.clojure/clojure "1.7.0-RC1"]
+  :dependencies [[org.clojure/clojure "1.7.0"]
                  [ring "1.2.1"]
                  [compojure "1.1.6"]
                  [aleph "0.3.0-rc2"]

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :min-lein-version "2.0.0"
   :source-paths ["src/clj" "target/generated/clj"]
   :test-paths ["test/clj"]
-  :dependencies [[org.clojure/clojure "1.6.0"]
+  :dependencies [[org.clojure/clojure "1.7.0-RC1"]
                  [ring "1.2.1"]
                  [compojure "1.1.6"]
                  [aleph "0.3.0-rc2"]

--- a/src/clj/clojuredocs/pages/vars.clj
+++ b/src/clj/clojuredocs/pages/vars.clj
@@ -40,7 +40,7 @@
 
 (defn source-url [{:keys [file line ns]}]
   (when (= "clojure.core" ns)
-    (str "https://github.com/clojure/clojure/blob/clojure-1.6.0/src/clj/" file "#L" line)))
+    (str "https://github.com/clojure/clojure/blob/clojure-1.7.0/src/clj/" file "#L" line)))
 
 (defn lookup-var [ns name]
   (search/lookup (str ns "/" name)))

--- a/src/clj/clojuredocs/search.clj
+++ b/src/clj/clojuredocs/search.clj
@@ -101,8 +101,8 @@
 
 (def clojure-lib
   (-> {:library-url "https://github.com/clojure/clojure"
-       :version "1.6.0"
-       :source-base-url "https://github.com/clojure/clojure/1.6.0/blob"
+       :version "1.7.0"
+       :source-base-url "https://github.com/clojure/clojure/1.7.0/blob"
        :namespaces static/clojure-namespaces}
       gather-namespaces
       gather-vars))


### PR DESCRIPTION
Pretty straightforward, all CD needs to pull in new vars is the new Clojure version:

Autocomplete for new vars:

![](http://cl.ly/image/3B290G3T1s1a/Screen%20Shot%202015-06-07%20at%206.11.30%20PM.png)


Var page w/ examples

![](http://cl.ly/image/2Y3p3z2t0P2Q/Screen%20Shot%202015-06-07%20at%206.13.23%20PM.png)


New transducer arity:

![](http://cl.ly/image/0u3k23341M2P/Screen%20Shot%202015-06-07%20at%206.13.40%20PM.png)