### PR TITLE
Performs character escaping on additional elements

### DIFF
--- a/src/clj/clojuredocs/pages/common.clj
+++ b/src/clj/clojuredocs/pages/common.clj
@@ -145,7 +145,7 @@
     font-awesome-link
     bootstrap-link
     app-link
-    [:script "window.PAGE_DATA=" (util/to-json (pr-str page-data)) ";"]]
+    [:script "// <![CDATA[\nwindow.PAGE_DATA=" (util/to-json (pr-str page-data)) ";\n//]]>"]]
    [:body
     (when body-class
       {:class body-class})

--- a/src/clj/clojuredocs/pages/vars.clj
+++ b/src/clj/clojuredocs/pages/vars.clj
@@ -24,11 +24,11 @@
    (str "("
         (util/html-encode name)
         (when-not (empty? a) " ")
-        a
+        (util/html-encode a)
         ")")])
 
 (defn $argform [s]
-  [:li.arglist s])
+  [:li.arglist (util/html-encode s)])
 
 (defn see-alsos-for [{:keys [ns name library-url]}]
   (->> (mon/fetch :see-alsos
@@ -137,7 +137,7 @@
            :body
            (common/$main
              {:body-class "var-page"
-              :title (str name " - " ns " | ClojureDocs - Community-Powered Clojure Documentation and Examples")
+              :title (util/html-encode (str name " - " ns " | ClojureDocs - Community-Powered Clojure Documentation and Examples"))
               :page-data {:examples (mapv clean-example examples)
                           :var v
                           :notes (vec (map clean-id notes))

--- a/src/cljx/clojuredocs/util.cljx
+++ b/src/cljx/clojuredocs/util.cljx
@@ -38,6 +38,7 @@
 (defn html-encode [s]
   (when s
     (-> s
+        (str/replace #"&" "&amp;")
         (str/replace #"<" "&lt;")
         (str/replace #">" "&gt;"))))
 


### PR DESCRIPTION
Adds character escaping for '&'. Escapes characters in the title and
arglist. Declares page data as CDATA.

Those changes help HTML parsers to correctly parse the document.