### PR TITLE
Add opensearch capabilities

### DIFF
--- a/resources/public/opensearch.xml
+++ b/resources/public/opensearch.xml
@@ -1,0 +1,9 @@
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+  <ShortName>ClojureDocs</ShortName>
+  <Description>
+    ClojureDocs is a community-powered documentation and examples repository for the Clojure programming language.
+  </Description>
+  <InputEncoding>UTF-8</InputEncoding>
+  <Image width="16" height="16" type="image/x-icon">http://clojuredocs.org/favicon.ico</Image>
+  <Url type="text/html" method="get" template="http://www.clojuredocs.org/search?q={searchTerms}"/>
+</OpenSearchDescription>

--- a/src/clj/clojuredocs/pages/common.clj
+++ b/src/clj/clojuredocs/pages/common.clj
@@ -126,7 +126,7 @@
           :href (str "/css/font-awesome.min.css?"
                      (md5-path "resources/public/css/font-awesome.min.css"))}])
 
-(def omnisearch-link
+(def opensearch-link
   [:link {:rel "search"
           :href "/opensearch.xml"
           :type "application/opensearchdescription+xml"
@@ -148,7 +148,7 @@
     [:meta {:name "apple-mobile-web-app-title" :content "ClojureDocs"}]
     [:meta {:name "google-site-verification" :content "XjzqkjEPtcgtLjhnqAvtnVSeveEccs-O_unFGGlbk4g"}]
     [:title (or title "Community-Powered Clojure Documentation and Examples | ClojureDocs")]
-    omnisearch-link
+    opensearch-link
     font-awesome-link
     bootstrap-link
     app-link

--- a/src/clj/clojuredocs/pages/common.clj
+++ b/src/clj/clojuredocs/pages/common.clj
@@ -126,6 +126,12 @@
           :href (str "/css/font-awesome.min.css?"
                      (md5-path "resources/public/css/font-awesome.min.css"))}])
 
+(def omnisearch-link
+  [:link {:rel "search"
+          :href "/opensearch.xml"
+          :type "application/opensearchdescription+xml"
+          :title "ClojureDocs"}])
+
 (defn $main [{:keys [page-uri
                      content
                      title
@@ -142,6 +148,7 @@
     [:meta {:name "apple-mobile-web-app-title" :content "ClojureDocs"}]
     [:meta {:name "google-site-verification" :content "XjzqkjEPtcgtLjhnqAvtnVSeveEccs-O_unFGGlbk4g"}]
     [:title (or title "Community-Powered Clojure Documentation and Examples | ClojureDocs")]
+    omnisearch-link
     font-awesome-link
     bootstrap-link
     app-link
@@ -247,7 +254,7 @@ document.location.href = noddy.href;
     {:src (or avatar-url
               (str "https://www.gravatar.com/avatar/"
                    (util/md5 email)
-                   "?r=PG&s=32&default=identicon")) }]])
+                   "?r=PG&s=32&default=identicon"))}]])
 
 (defn group-levels [path ns-lookup current-ns ls]
   (when-not (empty? ls)


### PR DESCRIPTION
This adds the ability to press `TAB` in Chrome's OmniBox to search ClojureDocs. I use the site quite a bit, and I've found this shortcut to be handy on a lot of other services. :smile: 

Screenshot example:
<img width="293" alt="screen shot 2016-01-09 at 3 23 12 pm" src="https://cloud.githubusercontent.com/assets/3742606/12218446/f633fb16-b6e4-11e5-8980-52830ac6dea9.png">
