### PR TITLE
fix broken link to SoundCloud logo

### DIFF
--- a/src/clj/clojuredocs/pages/intro.clj
+++ b/src/clj/clojuredocs/pages/intro.clj
@@ -208,7 +208,7 @@
                :url "https://www.heroku.com"}
               {:src "https://img.brightcove.com/logo-corporate-new.png"
                :url "http://www.brightcove.com"}
-              {:src "https://upload.wikimedia.org/wikipedia/en/9/92/SoundCloud_logo.svg"
+              {:src "https://upload.wikimedia.org/wikipedia/commons/f/f4/SoundCloud_logo%2C_orange_color%2C_plain.svg"
                :url "https://soundcloud.com"}
               {:src "/img/puppet-logo.jpg"
                :url "https://puppet.com"}


### PR DESCRIPTION
The previous one was 404'ing. It might be worth hosting it to avoid this kind of issue in the future.

![](https://cloud.githubusercontent.com/assets/1334295/21846052/774afbe6-d7f5-11e6-9c55-ac1ec22e25ac.png)