### PR TITLE
Don't show see-alsos with missing target var. Fixes #158

### DIFF
--- a/src/clj/clojuredocs/pages/vars.clj
+++ b/src/clj/clojuredocs/pages/vars.clj
@@ -36,7 +36,11 @@
                  :from-var.name name
                  :from-var.library-url library-url})
        (map (fn [{:keys [to-var] :as sa}]
-              (assoc sa :doc (-> (str (:ns to-var) "/" (:name to-var)) search/lookup :doc))))))
+         (let [ns-name (str (:ns to-var) "/" (:name to-var))
+               looked-up-var (search/lookup ns-name)]
+           (if (nil? looked-up-var) nil
+               (assoc sa :doc (:doc looked-up-var))))))
+       (remove nil?)))
 
 (defn source-url [{:keys [file line ns]}]
   (when (= "clojure.core" ns)


### PR DESCRIPTION
Prevents those see-alsos from being displayed for which `search/lookup` didn't yield a result for the see-also's `:to-var`.

While this prevents broken links from appearing on the site it might be worth thinking about a way to clean up the mongodb from see-alsos like this. Maybe a run a script every time a new clojure version comes out and eliminate the affected see-alsos in mongodb.