### PR TITLE
Link to correct profile for unmigrated users in see-alsos. Fixes #160

### DIFF
--- a/src/cljc/clojuredocs/util.cljc
+++ b/src/cljc/clojuredocs/util.cljc
@@ -109,14 +109,17 @@
       :cljs
       (.now js/Date)))
 
+(defn profile-url [{:keys [login account-source]}]
+  (str (if (= "github" account-source)
+         "/u/"
+         "/uc/")
+    login))
+
 (defn $avatar [{:keys [email login avatar-url account-source] :as user} & [{:keys [size]}]]
   (let [size (str (or size 32))]
     ^{:key (or avatar-url email)}
     [:a.avatar-link
-     {:href (str (if (= "github" account-source)
-                   "/u/"
-                   "/uc/")
-                 login)}
+     {:href (profile-url user)}
      [:img.avatar
       {:src (or (str avatar-url "&s=" size)
                 (str "https://www.gravatar.com/avatar/"

--- a/src/cljs/clojuredocs/see_alsos.cljs
+++ b/src/cljs/clojuredocs/see_alsos.cljs
@@ -33,7 +33,7 @@
         "...")]
      [:div.meta
       "Added by "
-      [:a {:href (str "/u/" (:login author))} (:login author)]
+      [:a {:href (util/profile-url author)} (:login author)]
       (when can-delete?
         [:span.delete-controls
          " / "


### PR DESCRIPTION
Introduces a new `profile-url` function that constructs the appropriate profile link for users whether they were migrated to github or not.

Use that function for avatars as well as see-alsos.