### PR TITLE
url-decode spaces in login names. Fixes #162

### DIFF
--- a/src/clj/clojuredocs/pages/user.clj
+++ b/src/clj/clojuredocs/pages/user.clj
@@ -10,7 +10,7 @@
 
 (defn page-handler [login account-source]
   (let [{:keys [login account-source] :as user}
-        (mon/fetch-one :users :where {:login (codec/percent-decode login)
+        (mon/fetch-one :users :where {:login (codec/url-decode login)
                                       :account-source account-source})
 
         examples-authored-count

--- a/src/clj/clojuredocs/pages/user.clj
+++ b/src/clj/clojuredocs/pages/user.clj
@@ -4,12 +4,14 @@
             [clojuredocs.pages.common :as common]
             [clojuredocs.mail :as mail]
             [somnium.congomongo :as mon]
+            [ring.util.codec :as codec]
             [ring.util.response :refer (redirect)]
             [compojure.core :refer (defroutes GET)]))
 
 (defn page-handler [login account-source]
   (let [{:keys [login account-source] :as user}
-        (mon/fetch-one :users :where {:login login :account-source account-source})
+        (mon/fetch-one :users :where {:login (codec/percent-decode login)
+                                      :account-source account-source})
 
         examples-authored-count
         (mon/fetch-count :examples :where {:author.login login


### PR DESCRIPTION
This just url-decodes login names like `Brian%20Marick` back to `Brian Marick` so that the mongodb lookup for the user entry doesn't fail.