### PR TITLE
Don't decode + signs in URL paths. Fixes #164

### DIFF
--- a/src/clj/clojuredocs/pages/vars.clj
+++ b/src/clj/clojuredocs/pages/vars.clj
@@ -5,6 +5,7 @@
             [clojuredocs.search :as search]
             [clojuredocs.pages.common :as common]
             [clojuredocs.data :as data]
+            [ring.util.codec :as codec]
             [hiccup.core :as hc]))
 
 (defn ellipsis [s n]
@@ -110,7 +111,7 @@
         (map #($arglist name %) arglists))]]]])
 
 (defn var-page-handler [ns name]
-  (let [name (util/cd-decode (util/url-decode name))
+  (let [name (util/cd-decode (codec/url-decode name))
         {:keys [arglists name ns doc runtimes added file] :as v} (lookup-var ns name)]
     (fn [{:keys [user session uri]}]
       (when v


### PR DESCRIPTION
This fixes #164. The problem is caused by the fact that the path portion and the query string in a URL are encoded in different ways:

* In the path portion of a URL (like `/clojure.core/+'`) the `+` sign is interpreted literally. It's not interpreted as a space.
* In the query string of a URL (like `?param=foo+bar`) the `+` sign **is** interpreted as a space. Same is true in query parameters that are POSTed as `application/x-www-form-urlencoded`.

(See [this StackOverflow answer and its comments](http://stackoverflow.com/a/1006074/5892036) for the relevant RFCs.)

However [`clojuredocs.pages.vars/var-page-handler`](https://github.com/zk/clojuredocs/blob/32d3354deb98a7d3a37a536461d9bbdf505dcc9f/src/clj/clojuredocs/pages/vars.clj#L113) uses [`clojuredocs.util/url-decode`](https://github.com/zk/clojuredocs/blob/32d3354deb98a7d3a37a536461d9bbdf505dcc9f/src/cljc/clojuredocs/util.cljc#L22) which relies on [`java.net.URLDecoder`](http://docs.oracle.com/javase/6/docs/api/java/net/URLDecoder.html).

Since `java.net.URLDecoder` is meant to handle `application/x-www-form-urlencoded` text, it can handle either query strings or POSTed form parameters, **not** URL path portions. 

That means a var name like `+'` gets decoded to <code> '</code>. Since there is no var named <code> '</code> the lookup fails and the [fallback route](https://github.com/zk/clojuredocs/blob/32d3354deb98a7d3a37a536461d9bbdf505dcc9f/src/clj/clojuredocs/pages.clj#L360) sends a redirect to the exact same URL causing a redirect loop.

This is solved by using the appropriate [`ring` decoder](http://ring-clojure.github.io/ring-codec/ring.util.codec.html) (see also this [issue comment](https://github.com/ring-clojure/ring-codec/issues/12#issuecomment-162671917)) of which `ring` provides two:

* [url-decode](http://ring-clojure.github.io/ring-codec/ring.util.codec.html#var-url-decode) for path portions in URLs.
* [form-decode](http://ring-clojure.github.io/ring-codec/ring.util.codec.html#var-form-decode) for POSTed form params and query strings in URLs.

Using `url-decode` fixes the issue.
