### PR TITLE
Use Bash for all bin/ scripts

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/bin/clean
+++ b/bin/clean
@@ -1,4 +1,4 @@
-#/bin/sh
+#/bin/bash
 
 rm -rf ./resources/public/cljs
 rm -rf ./resources/public/cljs-advanced

--- a/bin/dev
+++ b/bin/dev
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 

--- a/bin/prod-local
+++ b/bin/prod-local
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 


### PR DESCRIPTION
These scripts are already written in Bash, but on some OSes `/bin/sh` is aliased to Bash. On those where it’s not they fail to run due to Bash-specific things like `BASH_SOURCE`.