### PR TITLE
Fix a link broken by a trailing slash

### DIFF
--- a/src/md/namespaces/clojure.core.async.md
+++ b/src/md/namespaces/clojure.core.async.md
@@ -6,6 +6,6 @@ Channel primitives for building asynchronous programs. **Core.async is not provi
 * [Blog post announcing core.async](http://clojure.com/blog/2013/06/28/clojure-core-async-channels.html)
 * [Source repo](https://github.com/clojure/core.async)
 * [Rich Hickey on core.async](http://www.infoq.com/presentations/clojure-core-async) (video)
-* [Communicating Sequential Processes](http://swannodette.github.io/2013/07/12/communicating-sequential-processes/) by David Nolen
+* [Communicating Sequential Processes](http://swannodette.github.io/2013/07/12/communicating-sequential-processes) by David Nolen
 * [Brave Clojure: Mastering Concurrent Processes with core.async](http://www.braveclojure.com/core-async/)
 * [Go Block Best Practices](https://github.com/clojure/core.async/wiki/Go-Block-Best-Practices)


### PR DESCRIPTION
The trailing slash on the URL breaks the link. Not much more to say :sunglasses: 