### PR TITLE
Add ‘seqable?’ in quickref

### DIFF
--- a/src/clj/clojuredocs/pages/quickref/static.clj
+++ b/src/clj/clojuredocs/pages/quickref/static.clj
@@ -269,7 +269,7 @@
          (contains?
            distinct? empty? every? not-every? some not-any?),
          :title "Content Tests"}
-        {:syms (sequential? associative? sorted? counted? reversible?),
+        {:syms (sequential? associative? sorted? counted? reversible? seqable?),
          :title "Capabilities"}
         {:syms (coll? seq? vector? list? map? set?),
          :title "Type Tests"})}


### PR DESCRIPTION
This adds `seqable?` (since 1.9) to the quickref.

I’ve added it under Collections > Capabilities. This seems appropriate enough but could also be somewhere under Sequences.

Thank you!
