### PR TITLE
Updated to Clojure 1.10.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Clojure vars are pulled directly from the runtime, and are not stored in the dat
 * Change the Clojure dep in `project.clj`
 * Update the version string, source base url, and gh tag url in
   `clojuredocs.search/clojure-lib`
+* Update the version for the mobile nav in `clojuredocs.pages.common`
 * Update the github URL in `clojuredocs.pages.vars/source-url`.
 
 

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
-(defproject clojuredocs "0.2.0"
-  :description "The clojuredocs.org web app"
-  :url "http://clojuredocs.org"
+(defproject clojuredocs "0.1.0-SNAPSHOT"
+  :description "FIXME: write description"
+  :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :min-lein-version "2.0.0"

--- a/project.clj
+++ b/project.clj
@@ -1,12 +1,12 @@
-(defproject clojuredocs "0.1.0-SNAPSHOT"
-  :description "FIXME: write description"
-  :url "http://example.com/FIXME"
+(defproject clojuredocs "0.2.0"
+  :description "The clojuredocs.org web app"
+  :url "http://clojuredocs.org"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :min-lein-version "2.0.0"
   :source-paths ["src/clj" "src/cljc"]
   :test-paths ["test/clj"]
-  :dependencies [[org.clojure/clojure "1.9.0"]
+  :dependencies [[org.clojure/clojure "1.10.1"]
                  [org.clojure/clojurescript "1.9.946"]
                  [nsfw "0.11.72" :exclusions
                   [org.clojure/core.async

--- a/src/clj/clojuredocs/pages/common.clj
+++ b/src/clj/clojuredocs/pages/common.clj
@@ -89,7 +89,7 @@
     [:ul.navbar-nav.mobile-navbar-nav.nav
      [:li
       [:a {:href "/core-library"} "Core Library"
-       [:span.clojure-version "(1.9.0 a14)"]]]
+       [:span.clojure-version "(1.10.1)"]]]
      [:li [:a {:href "/quickref"} "Quick Reference"]]
      (if user
        ($user-area user)

--- a/src/clj/clojuredocs/pages/vars.clj
+++ b/src/clj/clojuredocs/pages/vars.clj
@@ -45,7 +45,7 @@
 
 (defn source-url [{:keys [file line ns] :as var}]
   (when (and (= "clojure.core" ns) file)
-    (str "https://github.com/clojure/clojure/blob/clojure-1.9.0/src/clj/" file "#L" line)))
+    (str "https://github.com/clojure/clojure/blob/clojure-1.10.1/src/clj/" file "#L" line)))
 
 (defn lookup-var [ns name]
   (search/lookup (str ns "/" name)))

--- a/src/clj/clojuredocs/search.clj
+++ b/src/clj/clojuredocs/search.clj
@@ -101,9 +101,9 @@
 
 (def clojure-lib
   (-> {:library-url "https://github.com/clojure/clojure"
-       :version "1.9.0"
-       :source-base-url "https://github.com/clojure/clojure/1.9.0/blob"
-       :gh-tag-url "https://github.com/clojure/clojure/tree/clojure-1.9.0"
+       :version "1.10.1"
+       :source-base-url "https://github.com/clojure/clojure/1.10.1/blob"
+       :gh-tag-url "https://github.com/clojure/clojure/tree/clojure-1.10.1"
        :namespaces static/clojure-namespaces}
       gather-namespaces
       gather-vars))

--- a/src/clj/clojuredocs/search/static.clj
+++ b/src/clj/clojuredocs/search/static.clj
@@ -6,8 +6,11 @@
     clojure.core.logic
     clojure.core.logic.fd
     clojure.core.logic.pldb
+    clojure.core.protocols
     clojure.core.reducers
+    clojure.core.server
     clojure.data
+    clojure.datafy
     clojure.edn
     clojure.inspector
     clojure.instant
@@ -25,6 +28,8 @@
     clojure.string
     clojure.template
     clojure.test
+    clojure.test.junit
+    clojure.test.tap
     clojure.walk
     clojure.xml
     clojure.zip])


### PR DESCRIPTION
For issue https://github.com/zk/clojuredocs/issues/198
Now we have the new vars and namespaces added in Clojure 1.10.1. Done just as described under [clojure-version](https://github.com/zk/clojuredocs#clojure-version). Also added some of the namespaces listed uner #198.