### PR TITLE
Added more links on destructuring

### DIFF
--- a/src/md/concepts/destructuring.md
+++ b/src/md/concepts/destructuring.md
@@ -41,4 +41,8 @@ structure of the passed map:
 
 ```
 
-See John Del Rosario's [destructuring cheat sheet](https://gist.github.com/john2x/e1dca953548bfdfb9844) for a more comprehensive overview.
+* For more detailed take on destructuring see Daniel Gregoire's [blog post](https://danielgregoire.dev/posts/2021-06-13-code-observation-clojure-destructuring/).
+* Bruno Bonacci's [guide on destructuring](https://blog.brunobonacci.com/2014/11/16/clojure-complete-guide-to-destructuring/) is worth a look.
+* Jay Field's [introductory blog post](http://blog.jayfields.com/2010/07/clojure-destructuring.html) provides a good starting point.
+* See John Del Rosario's [destructuring cheat sheet](https://gist.github.com/john2x/e1dca953548bfdfb9844) for a more comprehensive overview.
+* Also there is [the official Clojure guide on destructuring](https://clojure.org/guides/destructuring).


### PR DESCRIPTION
Hello @zk 

Thank you for maintaining this project, it's super useful.
Please consider this contribution.

I've added a few more links on destructuring as it's such a relevant topic.

My reasoning for including the links:

I've added link to Daniel Gregoire blog post, because it's the most up to date and complete guide. See for yourself: https://danielgregoire.dev/posts/2021-06-13-code-observation-clojure-destructuring/

Bruno's blog post, was for me, until Daniel's post was published, the go to reference. See: https://blog.brunobonacci.com/2014/11/16/clojure-complete-guide-to-destructuring/

I've added Jay's blog post because of the historical context and there is a discussion/comments below it by **fogus** is now core maintainer of Clojure. See: http://blog.jayfields.com/2010/07/clojure-destructuring.html

And finally, I added Clojure's own documentation link for completeness.