### PR TITLE
Correct URL for twitter logo (previous one 404s)

### DIFF
--- a/src/clj/clojuredocs/pages/intro.clj
+++ b/src/clj/clojuredocs/pages/intro.clj
@@ -198,7 +198,7 @@
                :url "http://www.climate.com/"}
               {:src "/img/funding-circle-logo.png"
                :url "https://www.fundingcircle.com"}
-              {:src "https://g.twimg.com/Twitter_logo_blue.png"
+              {:src "https://help.twitter.com/content/dam/help-twitter/brand/logo.png"
                :url "https://twitter.com"}
               {:src "/img/factual-logo.png"
                :url "http://www.factual.com"}


### PR DESCRIPTION
Previous twitter "bird logo" URL is a 400/404 error.

The twitter main site uses SVG now for most of the birds, but this one seems like an official URL in the Twitter digital asset manager.
